### PR TITLE
return empty object if netrc is empty, instead of a undefined key/value

### DIFF
--- a/lib/netrc.js
+++ b/lib/netrc.js
@@ -49,6 +49,9 @@ function netrc (path) {
 function parse (netrc) {
 	var result = {};
 	var host, login, password;
+
+	// if netrc content is empty, just return empty object
+	if(!netrc) return result;
 	
 	netrc.split('\n').forEach(function (line) {
 		if (/^(machine|default)/i.test(line)) {

--- a/test/netrc.test.js
+++ b/test/netrc.test.js
@@ -47,4 +47,9 @@ describe ('Netrc', function () {
 		machines['example.org'][0].should.equal('some_user');
 		machines['example.org'][1].should.equal('');
 	});
+
+	it('should return empty object if netrc file not exist', function () {
+		var machines = netrc(__dirname + '/fixtures/empty-netrc');
+		machines.should.be.empty;
+	})
 });


### PR DESCRIPTION
Hi, if netrc file is empty

`machines.save()` will save following content to netrc

```
machine undefined
    login undefined
```

so, in this pull request, I return an empty object instead of trying to assign `undefined` to `result`
